### PR TITLE
fix: change version sorting from descending to ascending order

### DIFF
--- a/packages.lua
+++ b/packages.lua
@@ -44,7 +44,7 @@ end
 
 function _sort_versions(versions)
     table.sort(versions, function(a, b)
-        return semver.compare(a, b) > 0
+        return semver.compare(a, b) < 0
     end)
     return versions
 end


### PR DESCRIPTION
修复xmake.microblock.cc 上显示包最新版本号错误的问题。

https://xmake.microblock.cc/package/abseil
绿色框才是正确的

<img width="814" height="1182" alt="图片" src="https://github.com/user-attachments/assets/292cc321-80bf-487f-b0dc-f42ccff95b74" />

本次修改后，预期latest version显示正确，Available Versions 按版本号从大到小排列